### PR TITLE
Svelte kit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@sveltejs/adapter-node": "^1.0.0-next.83",
         "@sveltejs/kit": "next",
         "eslint-plugin-svelte3": "^4.0.0",
-        "image-amalgamator": "^1.3.0",
+        "image-amalgamator": "^1.4.0",
         "jimp": "^0.16.1",
         "svelte": "^3.44.0",
         "vite": "^3.0.0"
@@ -2013,9 +2013,9 @@
       }
     },
     "node_modules/image-amalgamator": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/image-amalgamator/-/image-amalgamator-1.3.0.tgz",
-      "integrity": "sha512-TK7uG/JQ5F6fR2+YzIoAAKdzj6B0mv97hrJFq4yxe9rBOoc7YLsdnX1O/ljhHGbGWymcjgf86tblSfBCxP47hA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/image-amalgamator/-/image-amalgamator-1.4.0.tgz",
+      "integrity": "sha512-VZYSqwE2og8HG7CklXDHpezjDBSdZb+ibYSBHaDVZk5P2oCgg7FEtT36V+IknYmHm+CergIfvdDrq9xza4Ja6g==",
       "dev": true,
       "dependencies": {
         "jimp": "^0.16.1"
@@ -4787,9 +4787,9 @@
       "peer": true
     },
     "image-amalgamator": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/image-amalgamator/-/image-amalgamator-1.3.0.tgz",
-      "integrity": "sha512-TK7uG/JQ5F6fR2+YzIoAAKdzj6B0mv97hrJFq4yxe9rBOoc7YLsdnX1O/ljhHGbGWymcjgf86tblSfBCxP47hA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/image-amalgamator/-/image-amalgamator-1.4.0.tgz",
+      "integrity": "sha512-VZYSqwE2og8HG7CklXDHpezjDBSdZb+ibYSBHaDVZk5P2oCgg7FEtT36V+IknYmHm+CergIfvdDrq9xza4Ja6g==",
       "dev": true,
       "requires": {
         "jimp": "^0.16.1"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@sveltejs/adapter-node": "^1.0.0-next.83",
     "@sveltejs/kit": "next",
     "eslint-plugin-svelte3": "^4.0.0",
-    "image-amalgamator": "^1.3.0",
+    "image-amalgamator": "^1.4.0",
     "jimp": "^0.16.1",
     "svelte": "^3.44.0",
     "vite": "^3.0.0"

--- a/src/lib/imageProcessing/merger.js
+++ b/src/lib/imageProcessing/merger.js
@@ -16,7 +16,7 @@ export async function imgGen(input) {
     }
 
     // Merge & scale images: https://github.com/PiPinecone/Image-Amalgamator
-    await amalg.mergeImages(outputImgs, finPath, 223.5, 273.5);
+    await amalg.mergeImages(outputImgs, finPath /*, 500, 273.5*/);
 
     return finPath;
 }

--- a/src/lib/imageProcessing/merger.js
+++ b/src/lib/imageProcessing/merger.js
@@ -16,7 +16,7 @@ export async function imgGen(input) {
     }
 
     // Merge & scale images: https://github.com/PiPinecone/Image-Amalgamator
-    await amalg.mergeImages(outputImgs, finPath/*, 223.5, 273.5*/);
+    await amalg.mergeImages(outputImgs, finPath, 223.5, 273.5);
 
     return finPath;
 }

--- a/src/lib/imageProcessing/merger.js
+++ b/src/lib/imageProcessing/merger.js
@@ -1,9 +1,8 @@
 import amalg from "image-amalgamator";
-import Jimp from "jimp";
 
 const colors = ["Red", "Orange", "Yellow", "Green", "Blue", "Violet"];
 
-export function imgGen(input) {
+export async function imgGen(input) {
     let outputImgs = [];
 
     const finPath = `./cache/img/${input.toLowerCase()}.png`;
@@ -17,7 +16,7 @@ export function imgGen(input) {
     }
 
     // Merge & scale images: https://github.com/PiPinecone/Image-Amalgamator
-    amalg.mergeImages(outputImgs, finPath/*, 223.5, 273.5*/);
+    await amalg.mergeImages(outputImgs, finPath/*, 223.5, 273.5*/);
 
     return finPath;
 }

--- a/src/lib/imageProcessing/merger.js
+++ b/src/lib/imageProcessing/merger.js
@@ -17,7 +17,7 @@ export function imgGen(input) {
     }
 
     // Merge & scale images: https://github.com/PiPinecone/Image-Amalgamator
-    amalg.mergeImages(outputImgs, finPath, 223.5, 273.5);
+    amalg.mergeImages(outputImgs, finPath/*, 223.5, 273.5*/);
 
     return finPath;
 }

--- a/src/lib/imageProcessing/merger.js
+++ b/src/lib/imageProcessing/merger.js
@@ -10,7 +10,7 @@ export function imgGen(input) {
     let inputText = input.toUpperCase();
     inputText = inputText.split("");
     
-    // Make the R A I N B O W
+    // Colorize images
     for(let i = 6; i < inputText.length + 6; i++) {
         // Choose colors and push file paths
         outputImgs.push(`./static/Letters/${colors[i % 6]}/${inputText[i - 6]}.png`);
@@ -21,5 +21,3 @@ export function imgGen(input) {
 
     return finPath;
 }
-
-imgGen("hello", "./cache/img/outt.png");

--- a/src/routes/api/generate.js
+++ b/src/routes/api/generate.js
@@ -5,14 +5,15 @@ import { imgGen } from '$lib/imageProcessing/merger.js'
 export async function POST({ request }) {
   let output = await request.formData();
   let input = output.get("inputString");
+  let fnRet = await imgGen(input);
 
     return {
       status: 303,
       headers: {
-        location: `/?imgPath=${await imgGen(input)}`
+        location: `/?imgPath=${fnRet}`
       },
       body: {
-        imgPath: await imgGen(input)
+        imgPath: fnRet
       }
     };
   }

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,6 +1,6 @@
 <script context="module">
     export function load({ url }) {
-        let path = url.searchParams.get('imgPath')
+        let path = url.searchParams.get('imgPath') || ""
         return {
             props: {
                 path
@@ -12,11 +12,12 @@
 <script>
     export let path;
     $: p2 = path;
+    console.log(p2);
 </script>
 
 
 <div class="header">
-    <img src="../static/logo.png" alt="ASCII" width="700" height="170"/>
+    <img src="./logo.png" alt="ASCII" width="700" height="170"/>
 </div>
 
 <br/>
@@ -66,6 +67,8 @@
         margin-top: 50px;
         margin-left: auto;
         margin-right: auto;
+
+        text-align: center;
     }
 
     label {
@@ -136,7 +139,7 @@
     }
 </style>
 
-{#if path == ""}
+{#if p2 == ""}
     <style>
         #outputImage {
             visibility: hidden;

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -11,8 +11,6 @@
 
 <script>
     export let path;
-    $: p2 = path;
-    console.log(p2);
 </script>
 
 
@@ -33,7 +31,7 @@
 <br/>
 
 <div class="imageBox">
-    <img src={p2} alt="Output" id="outputImage" width="225" height="275" />
+    <img src={path} alt="Output" id="outputImage" width="225" height="275" />
 </div>
 
 
@@ -139,7 +137,7 @@
     }
 </style>
 
-{#if p2 == ""}
+{#if path == ""}
     <style>
         #outputImage {
             visibility: hidden;

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -31,7 +31,7 @@
 <br/>
 
 <div class="imageBox">
-    <img src={path} alt="Output" id="outputImage" width="225" height="275" />
+    <img src={path} alt="Output" id="outputImage" width="850" height="250" />
 </div>
 
 


### PR DESCRIPTION
- Redirect now waits for image to be fully generated
- Images are sized appropriately, however longer words cause the final image to appear "smooshed" in the output box. This won't be a problem for the purpose of the user downloading a nice image (the download will use the **original**), but it doesn't look super good.
- Also may want to reconsider background colors